### PR TITLE
HttpClient Observe System properties

### DIFF
--- a/SensorsAnalyticsSDK/pom.xml
+++ b/SensorsAnalyticsSDK/pom.xml
@@ -15,7 +15,7 @@
     <groupId>com.sensorsdata.analytics.javasdk</groupId>
     <name>SensorsAnalyticsSDK</name>
     <artifactId>SensorsAnalyticsSDK</artifactId>
-    <version>3.1.17</version>
+    <version>3.1.18</version>
     <description>The official Java SDK of Sensors Analytics</description>
     <url>http://sensorsdata.cn</url>
 

--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
@@ -1075,8 +1075,7 @@ public class SensorsAnalytics {
       HttpUriRequest request = getHttpRequest(data);
       CloseableHttpResponse response = null;
       if (httpClient == null) {
-        httpClient = HttpClients
-                .custom()
+        httpClient = HttpClients.custom()
                 .useSystemProperties()
                 .setUserAgent("SensorsAnalytics Java SDK " + SDK_VERSION)
                 .build();

--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/SensorsAnalytics.java
@@ -1075,7 +1075,11 @@ public class SensorsAnalytics {
       HttpUriRequest request = getHttpRequest(data);
       CloseableHttpResponse response = null;
       if (httpClient == null) {
-        httpClient = HttpClients.custom().setUserAgent("SensorsAnalytics Java SDK " + SDK_VERSION).build();
+        httpClient = HttpClients
+                .custom()
+                .useSystemProperties()
+                .setUserAgent("SensorsAnalytics Java SDK " + SDK_VERSION)
+                .build();
       }
       try {
         response = httpClient.execute(request);


### PR DESCRIPTION
Alternative to #11 

This will enable you to use the following environment variables:
```
http.proxyHost
http.proxyPort
https.proxyHost
https.proxyPort
```
as well as others.