### PR TITLE
Add HttpClientBuilder as injectable dependency of HttpConsumer

### DIFF
--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/consumer/BatchConsumer.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/consumer/BatchConsumer.java
@@ -5,6 +5,8 @@ import com.sensorsdata.analytics.javasdk.util.SensorsAnalyticsUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -50,9 +52,14 @@ public class BatchConsumer implements Consumer {
     }
 
     public BatchConsumer(final String serverUrl, final int bulkSize, final int maxCacheSize,
-        final boolean throwException, final int timeoutSec) {
+                         final boolean throwException, final int timeoutSec) {
+        this(HttpClients.custom(), serverUrl, bulkSize, maxCacheSize, throwException, timeoutSec);
+    }
+
+    public BatchConsumer(HttpClientBuilder httpClientBuilder, final String serverUrl, final int bulkSize, final int maxCacheSize,
+                         final boolean throwException, final int timeoutSec) {
         this.messageList = new LinkedList<>();
-        this.httpConsumer = new HttpConsumer(serverUrl, Math.max(timeoutSec, 1));
+        this.httpConsumer = new HttpConsumer(httpClientBuilder, serverUrl, Math.max(timeoutSec, 1));
         this.jsonMapper = SensorsAnalyticsUtil.getJsonObjectMapper();
         this.bulkSize = Math.min(MAX_FLUSH_BULK_SIZE, Math.max(1, bulkSize));
         if (maxCacheSize > MAX_CACHE_SIZE) {

--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/consumer/DebugConsumer.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/consumer/DebugConsumer.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -23,6 +25,10 @@ public class DebugConsumer implements Consumer {
     final ObjectMapper jsonMapper;
 
     public DebugConsumer(final String serverUrl, final boolean writeData) {
+        this(HttpClients.custom(), serverUrl, writeData);
+    }
+
+    public DebugConsumer(HttpClientBuilder httpClientBuilder, String serverUrl, final boolean writeData) {
         String debugUrl;
         try {
             // 将 URI Path 替换成 Debug 模式的 '/debug'
@@ -41,7 +47,7 @@ public class DebugConsumer implements Consumer {
             headers.put("Dry-Run", "true");
         }
 
-        this.httpConsumer = new HttpConsumer(debugUrl, headers);
+        this.httpConsumer = new HttpConsumer(httpClientBuilder, debugUrl, headers);
         this.jsonMapper = SensorsAnalyticsUtil.getJsonObjectMapper();
         log.info("Initialize DebugConsumer with params:[writeData:{}].", writeData);
     }

--- a/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/consumer/FastBatchConsumer.java
+++ b/SensorsAnalyticsSDK/src/main/java/com/sensorsdata/analytics/javasdk/consumer/FastBatchConsumer.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,9 +64,14 @@ public class FastBatchConsumer implements Consumer {
 
   public FastBatchConsumer(@NonNull String serverUrl, final boolean timing, final int bulkSize, int maxCacheSize,
       int flushSec, int timeoutSec, @NonNull Callback callback) {
+    this(HttpClients.custom(), serverUrl, timing, bulkSize, maxCacheSize, flushSec, timeoutSec, callback);
+  }
+
+  public FastBatchConsumer(HttpClientBuilder httpClientBuilder, @NonNull String serverUrl, final boolean timing, final int bulkSize, int maxCacheSize,
+                           int flushSec, int timeoutSec, @NonNull Callback callback) {
     this.buffer =
         new LinkedBlockingQueue<>(Math.min(Math.max(MIN_CACHE_SIZE, maxCacheSize), MAX_CACHE_SIZE));
-    this.httpConsumer = new HttpConsumer(serverUrl, Math.max(timeoutSec, 1));
+    this.httpConsumer = new HttpConsumer(httpClientBuilder, serverUrl, Math.max(timeoutSec, 1));
     this.jsonMapper = SensorsAnalyticsUtil.getJsonObjectMapper();
     this.callback = callback;
     this.bulkSize = Math.min(MIN_CACHE_SIZE, Math.max(bulkSize, MIN_BULK_SIZE));


### PR DESCRIPTION
Adds HttpClinetBuilder for Apache HttpClient as a parameter for consumers in the Library, this will allow us to pass in a pre-configured client with additional proxy configurations. Additional constructors added so that the change is not a breaking evolution for the library.

closes #11 